### PR TITLE
Awake will skip Steam init if already started

### DIFF
--- a/FizzyFacepunch.cs
+++ b/FizzyFacepunch.cs
@@ -35,7 +35,14 @@ namespace Mirror.FizzySteam
             Debug.Assert(Channels != null && Channels.Length > 0, "No channel configured for FizzySteamMirror.");
             try
             {
-                SteamClient.Init(SteamAppID, false);
+                if (SteamClient.IsValid)
+                {
+                    Debug.Log($"Skipping Steam init, {nameof(SteamClient)} already started");
+                }
+                else
+                {
+                    SteamClient.Init(SteamAppID, false);
+                }
                 Invoke(nameof(FetchSteamID), 1f);
             }
             catch (Exception e)


### PR DESCRIPTION
Changes:
* Checks if SteamClient is already active before calling `SteamClient.Init`
* If it is active: a debug statement runs, and the init is skipped
* If it is not active: `SteamClient.Init` is called (no change in behavior)

I tested this in my project as server/host/client and had no issues.

Resolves #7.

