### PR TITLE
NextClient - Unsubscribe from OnConnectionStatus changed on Disconnect

### DIFF
--- a/NextClient.cs
+++ b/NextClient.cs
@@ -156,6 +156,7 @@ namespace Mirror.FizzySteam
     public void Disconnect()
     {
       cancelToken?.Cancel();
+      SteamNetworkingSockets.OnConnectionStatusChanged -= OnConnectionStatusChanged;
 
       if (HostConnectionManager != null)
       {


### PR DESCRIPTION
This prevents OnConnectionStatus from being called multiple times if you have previously Shutdown the network. Since a new NextClient seems to be created every time you reconnect, it appears the old ones were not being garbage collected and were getting OnConnectionStatusChanged events while not connected at all.