### PR TITLE
Fix #16 prevent connecting to yourself(SteamId)

### DIFF
--- a/FizzyFacepunch.cs
+++ b/FizzyFacepunch.cs
@@ -103,6 +103,12 @@ namespace Mirror.FizzySteam
         OnClientDisconnected.Invoke();
         return;
       }
+      
+      if (address == SteamUserID.ToString())
+      {
+        Debug.Log("You can't connect to yourself.");
+        return;
+      }
 
       FetchSteamID();
 


### PR DESCRIPTION
Steam doesn't support connecting to yourself through your own steamID.